### PR TITLE
Game 1 updates

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/TLTQ/src/Game.cpp
+++ b/TLTQ/src/Game.cpp
@@ -6,40 +6,63 @@ void Game::draw()
 	window.clear();
 	if (state == m_GameState::Menu)
 	{
-		mainTexture.loadFromFile("./graphics/climateStompersMainMenu.png");
+	    mainTexture.loadFromFile("./graphics/mainMenu.png");
 		mainSprite.setTexture(mainTexture);
+		mainSprite.setScale(4.f, 4.f);
 		window.draw(mainSprite);
 	}
 	else if (state == m_GameState::MainGame)
 	{
-		questions.emplace_back(m_Questions{ "Correct", "Incorrect", false, false, true });
-		mainTexture.loadFromFile("./graphics/climateStompersInGame.png");
+		mainTexture.loadFromFile("./graphics/inGame.png");
 		mainSprite.setTexture(mainTexture);
+        mainSprite.setScale(4.f, 4.f);
 		window.draw(mainSprite);
 
 		mainFont.loadFromFile("./fonts/Square.ttf");
 
 		sf::Text mainText("Choose the option that is best \nfor the environment!", mainFont, 36U);
 		mainText.setPosition(600.0f, 185.0f);
-		mainText.setFillColor(sf::Color::Black);
+		mainText.setFillColor(sf::Color::White);
+		window.draw(mainText);
 
 		sf::Text correctAnswer(questions[questionNum].correctText, mainFont, defaultFontSize);
 		correctAnswer.setPosition(584.0f, 788.0f);
-		correctAnswer.setFillColor(sf::Color::Black);
+		correctAnswer.setFillColor(sf::Color::White);
 		sf::Text incorrectAnswer(questions[questionNum].incorrectText, mainFont, defaultFontSize);
 		incorrectAnswer.setPosition(584.0f, 788.0f);
-		incorrectAnswer.setFillColor(sf::Color::Black);
+		incorrectAnswer.setFillColor(sf::Color::White);
 
-		if (questions[questionNum].answered && questions[questionNum].answeredCorrect)
-		{
-			window.draw(correctAnswer);
-		}
+        // All questions haven't been answered
+        if (questionNum < questions.size())
+        {
+            if (questions[questionNum].answered && questions[questionNum].answeredCorrect)
+            {
+                window.draw(correctAnswer);
+            }
 
-		else if (questions[questionNum].answered && !questions[questionNum].answeredCorrect)
-		{
-			window.draw(incorrectAnswer);
-		}
-
+            else if (questions[questionNum].answered && !questions[questionNum].answeredCorrect)
+            {
+                window.draw(incorrectAnswer);
+            }
+        }
+        // All questions answered - display win or lose
+        else
+        {
+            if (numCorrect >= (questions.size()  * winCondition))
+            {
+                winTexture.loadFromFile("./graphics/winScreen.png");
+                winSprite.setTexture(winTexture);
+                winSprite.setScale(4.f, 4.f);
+                window.draw(winSprite);
+            }
+            else
+            {
+                loseTexture.loadFromFile("./graphics/loseScreen.png");
+                loseSprite.setTexture(loseTexture);
+                loseSprite.setScale(4.f, 4.f);
+                window.draw(loseSprite);
+            }
+        }
 	}
 	else if (state == m_GameState::Paused)
 	{
@@ -56,41 +79,51 @@ void Game::update()
 	}
 	else if (state == m_GameState::MainGame)
 	{
-		if (mousePosition.x >= 578 && mousePosition.x <= 832 && mousePosition.y >= 460 && mousePosition.y <= 712 && !questions[questionNum].answered)
-		{
-			questions[questionNum].answered = true;
+        // All questions haven't been answered
+        if (questionNum < questions.size()) {
+            // If left answer selected and question not already answered
+            if (mousePosition.x >= 578 && mousePosition.x <= 832 && mousePosition.y >= 460 && mousePosition.y <= 712 &&
+                !questions[questionNum].answered) {
+                questions[questionNum].answered = true;
 
-			if (questions[questionNum].leftIsCorrect)
-			{
-				questions[questionNum].answeredCorrect = true;
-				numCorrect++;
-			}
-			else
-			{
-				questions[questionNum].answeredCorrect = false;
-			}
-		}
-		else if (mousePosition.x >= 1090 && mousePosition.x <= 1344 && mousePosition.y >= 460 && mousePosition.y <= 712 && !questions[questionNum].answered)
-		{
-			questions[questionNum].answered = true;
+                if (questions[questionNum].leftIsCorrect) {
+                    questions[questionNum].answeredCorrect = true;
+                    numCorrect++;
+                } else {
+                    questions[questionNum].answeredCorrect = false;
+                }
+            }
+            // If left answer selected and question not already answered
+            else if (mousePosition.x >= 1090 && mousePosition.x <= 1344 && mousePosition.y >= 460 &&
+                     mousePosition.y <= 712 && !questions[questionNum].answered) {
+                questions[questionNum].answered = true;
 
-			if (!questions[questionNum].leftIsCorrect)
-			{
-				questions[questionNum].answeredCorrect = true;
-				numCorrect++;
-			}
-			else
-			{
-				questions[questionNum].answeredCorrect = false;
-			}
-		}
-		else if (mousePosition.x >= 1696 && mousePosition.x <= 1886 && mousePosition.y >= 978 && mousePosition.y <= 1052 && questions[questionNum].answered)
-		{
-			if (++questionNum >= 1)
-			{
-				state = m_GameState::Menu;
-			}
-		}
+                if (!questions[questionNum].leftIsCorrect) {
+                    questions[questionNum].answeredCorrect = true;
+                    numCorrect++;
+                } else {
+                    questions[questionNum].answeredCorrect = false;
+                }
+            }
+            // If next button clicked and question already answered
+            else if (mousePosition.x >= 1696 && mousePosition.x <= 1886 && mousePosition.y >= 978 &&
+                     mousePosition.y <= 1052 && questions[questionNum].answered) {
+                if (++questionNum >= questions.size())
+                {
+                    // Leaving this in if statement since it's not working right if take it out
+                }
+            }
+        }
+        // All questions have been answered
+        else
+        {
+            // Home button clicked
+            if (mousePosition.x >= 762 && mousePosition.x <= 1156 && mousePosition.y >= 756 && mousePosition.y <= 834)
+            {
+                state = m_GameState::Menu;
+            }
+            // Play again button clicked
+        }
 	}
 	else if (state == m_GameState::Paused)
 	{
@@ -113,4 +146,10 @@ void Game::eventHandler()
 			std::cout << "Clicked\n";
 		}
 	}
+}
+
+void Game::loadQuestions(std::vector<m_Questions>& qs) {
+    // Will update to read .csv file
+    questions.emplace_back(m_Questions{ "Correct", "Incorrect", false, false, true });
+    questions.emplace_back(m_Questions{ "Correct2", "Incorrect2", false, false, true });
 }

--- a/TLTQ/src/Game.h
+++ b/TLTQ/src/Game.h
@@ -23,10 +23,15 @@ private:
     const uint32_t defaultFontSize = 24;
     uint32_t numCorrect{ 0 };
     uint32_t questionNum{ 0 };
+    float winCondition{0.75f};
     std::vector<m_Questions> questions;
 
     sf::Texture mainTexture;
     sf::Sprite mainSprite;
+    sf::Texture winTexture;
+    sf::Sprite winSprite;
+    sf::Texture loseTexture;
+    sf::Sprite loseSprite;
     sf::Font mainFont;
     sf::Vector2i mousePosition;
 
@@ -35,6 +40,7 @@ private:
     void update();
     void draw();
 
+    void loadQuestions(std::vector<m_Questions>& qs);
 
 
 public:
@@ -43,6 +49,7 @@ public:
     {
         window.create({ 1920, 1080 }, "Climate Stompers");
         state = m_GameState::Menu;
+        loadQuestions(questions);
     }
     void run()
     {


### PR DESCRIPTION
- Moved loading questions out of update() since it kept loading them every refresh & makes it harder to track the number of questions in the game. It's now a function in the constructor of Game(). I will work on the .csv part of this over the weekend.
- Next button is now (seemingly) functional to move through questions
- Win/lose screen shows when all questions have been answered depending if score > or < 75% (can change to whatever number makes sense)
- menu state now set when "home screen" clicked on win or lose screen.